### PR TITLE
fix typo in xmldoc for EnumerateDirectory

### DIFF
--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -846,7 +846,7 @@ namespace Microsoft.Azure.DataLake.Store
         }
         /// <summary>
         /// Returns a enumerable that enumerates the sub-directories or files contained in a directory.
-        /// By default listAfter and listBefore is empty and we enuerate all the directory entries.
+        /// By default listAfter and listBefore is empty and we enumerate all the directory entries.
         /// </summary>
         /// <param name="path">Path of the directory</param>
         /// <param name="userIdFormat">Way the user or group object will be represented</param>


### PR DESCRIPTION
There is a typo in "enumerate" in the xmldoc comment for the EnumerateDirectory method.