### PR TITLE
Fix conflict for parallel transfers for different account but same source and destination path in same host, Expose the option to disable transfer logging for bulk uploads and bulk downloads

### DIFF
--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -1525,9 +1525,36 @@ namespace Microsoft.Azure.DataLake.Store
         /// <returns>Transfer Status encapsulating the details of upload</returns>
         public virtual TransferStatus BulkUpload(string srcPath, string destPath, int numThreads = -1, IfExists shouldOverwrite = IfExists.Overwrite, IProgress<TransferStatus> progressTracker = null, bool notRecurse = false, bool resume = false, bool isBinary = false, CancellationToken cancelToken = default(CancellationToken))
         {
-            return FileUploader.Upload(srcPath, destPath, this, numThreads, shouldOverwrite, progressTracker, notRecurse, resume, isBinary, cancelToken);
+            return BulkUpload(srcPath, destPath, numThreads, shouldOverwrite, false, progressTracker, notRecurse, resume, isBinary, cancelToken);
         }
-
+        /// <summary>
+        /// Upload directory or file from local to remote. Transfers the contents under source directory under 
+        /// the destination directory. Transfers the source file and saves it as the destination path.
+        /// This method does not throw any exception for any entry's transfer failure. Refer the return value <see cref="TransferStatus"/> to 
+        /// get the status/exception of each entry's transfer.
+        /// By default logs the transfer progress in system's temp path, so that user can recover using <paramref name="resume"/> if upload has crashed.
+        /// This progress logging can be disabled using <paramref name="disableTransferLogging"/>.
+        /// It is highly recomended to set ServicePointManager.DefaultConnectionLimit to the number of threads application wants the sdk to use before creating any instance of AdlsClient.
+        /// By default ServicePointManager.DefaultConnectionLimit is set to 2.
+        /// By default files are uploaded at new line boundaries. However if files does not have newline within 4MB chunks,
+        /// the transfer will fail. In that case it is required to pass true to <paramref name="isBinary"/> to avoid uploads at newline boundaries.
+        /// </summary>
+        /// <param name="srcPath">Local source path</param>
+        /// <param name="destPath">Remote destination path - It should always be a directory.</param>
+        /// <param name="numThreads">Number of threads- Default -1, if not passed will take default number of threads (8 times the number of physical cores)</param>
+        /// <param name="shouldOverwrite">Whether to overwrite or skip if the destination exists, Default IfExists.Overwrite</param>
+        /// <param name="disableTransferLogging">If true, logging of transfer progress is disabled. This and <paramref name="resume"/> cannot be true at same time. Default false</param>
+        /// <param name="progressTracker">Progresstracker to track progress of file transfer, Default null</param>
+        /// <param name="notRecurse">If true then does an enumeration till level one else does recursive enumeration, Default false</param>
+        /// <param name="resume">If true then we want to resume from last transfer, Default false</param>
+        /// <param name="isBinary">If false then writes files to data lake at newline boundaries, however if the file has no newline within 4MB chunks it will throw exception.
+        /// If true, then upload at new line boundaries is not guranteed but the upload will be faster. By default false, if file has no newlines within 4MB chunks true should be apssed</param>
+        /// <param name="cancelToken">Cancellation token</param>
+        /// <returns>Transfer Status encapsulating the details of upload</returns>
+        public virtual TransferStatus BulkUpload(string srcPath, string destPath, int numThreads, IfExists shouldOverwrite, bool disableTransferLogging, IProgress<TransferStatus> progressTracker, bool notRecurse, bool resume, bool isBinary, CancellationToken cancelToken)
+        {
+            return FileUploader.Upload(srcPath, destPath, this, numThreads, shouldOverwrite, progressTracker, notRecurse, disableTransferLogging, resume, isBinary, cancelToken);
+        }
         /// <summary>
         /// Download directory or file from remote server to local. Transfers the contents under source directory under 
         /// the destination directory. Transfers the source file and saves it as the destination path.
@@ -1547,7 +1574,32 @@ namespace Microsoft.Azure.DataLake.Store
         /// <returns>Transfer status encapsulating the details of download</returns>
         public virtual TransferStatus BulkDownload(string srcPath, string destPath, int numThreads = -1, IfExists shouldOverwrite = IfExists.Overwrite, IProgress<TransferStatus> progressTracker = null, bool notRecurse = false, bool resume = false, CancellationToken cancelToken = default(CancellationToken))
         {
-            return FileDownloader.Download(srcPath, destPath, this, numThreads, shouldOverwrite, progressTracker, notRecurse, resume, cancelToken);
+            return BulkDownload(srcPath, destPath, numThreads, shouldOverwrite, false, progressTracker, notRecurse, resume, cancelToken);
+        }
+
+        /// <summary>
+        /// Download directory or file from remote server to local. Transfers the contents under source directory under 
+        /// the destination directory. Transfers the source file and saves it as the destination path.
+        /// This method does not throw any exception for any entry's transfer failure. Refer the return value <see cref="TransferStatus"/> to 
+        /// get the status/exception of each entry's transfer.
+        /// By default logs the transfer progress in system's temp path, so that user can recover using <paramref name="resume"/> if upload has crashed.
+        /// This progress logging can be disabled using <paramref name="disableTransferLogging"/>.
+        /// It is highly recomended to set ServicePointManager.DefaultConnectionLimit to the number of threads application wants the sdk to use before creating any instance of AdlsClient.
+        /// By default ServicePointManager.DefaultConnectionLimit is set to 2.
+        /// </summary>
+        /// <param name="srcPath">Remote source path</param>
+        /// <param name="destPath">Local destination path. It should always be a directory.</param>
+        /// <param name="numThreads">Number of threads- Default -1 if not passed will take default number of threads (8 times the number of physical cores)</param>
+        /// <param name="shouldOverwrite">Whether to overwrite or skip if the destination exists, Default IfExists.Overwrite</param>
+        /// <param name="disableTransferLogging">If true, logging of transfer progress is disabled. This and <paramref name="resume"/> cannot be true at same time. Default false</param>
+        /// <param name="progressTracker">Progresstracker to track progress of file transfer, Default null</param>
+        /// <param name="notRecurse">If true then does an enumeration till level one else does recursive enumeration, default false</param>
+        /// <param name="resume">If true then we want to resume from last transfer, default false</param>
+        /// <param name="cancelToken">Cancel token</param>
+        /// <returns>Transfer status encapsulating the details of download</returns>
+        public virtual TransferStatus BulkDownload(string srcPath, string destPath, int numThreads, IfExists shouldOverwrite, bool disableTransferLogging, IProgress<TransferStatus> progressTracker, bool notRecurse, bool resume, CancellationToken cancelToken)
+        {
+            return FileDownloader.Download(srcPath, destPath, this, numThreads, shouldOverwrite, progressTracker, notRecurse, disableTransferLogging, resume, cancelToken);
         }
 
         /// <summary>

--- a/AdlsDotNetSDK/FileTransfer/TransferStatus.cs
+++ b/AdlsDotNetSDK/FileTransfer/TransferStatus.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
         }
         public override string ToString()
         {
-            return $"JobStatus: {Status}, Error: {Errors}";
+            return $"EntryName: {EntryName}, EntryType: {Type}, JobStatus: {Status}, Error: {Errors}";
         }
     }
     /// <summary>

--- a/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
+++ b/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net452;netstandard1.4;netcoreapp1.1</TargetFrameworks>
     <PackageId>Microsoft.Azure.DataLake.Store</PackageId>
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
-	  <Version>1.1.19</Version>
+	  <Version>1.1.20</Version>
     <FileVersion>$(Version)</FileVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Microsoft</Authors>
     <Description>Microsoft Azure Data Lake Store Filesystem Library for Dot Net</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Avoid throwing exception while unable to deserialize the creationtime of the trash or directory entry, Expose setting per request timeout in adlsclient.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix conflict for parallel transfers for different account but same source and destination path in same host, Expose the option to disable transfer logging for bulk uploads and bulk downloads</PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-data-lake-store-net/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>

--- a/AdlsDotNetSDKUnitTest/TransferUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/TransferUnitTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestUploadNonBinary()
         {
-            TransferStatus status = FileUploader.Upload(LocalPathUpload1, RemotePathUpload1, _adlsClient, 10, IfExists.Overwrite, null, false, false, false, default(CancellationToken), false, TransferChunkSize);
+            TransferStatus status = FileUploader.Upload(LocalPathUpload1, RemotePathUpload1, _adlsClient, 10, IfExists.Overwrite, null, false, false, false, false, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(status.EntriesFailed.Count == 0);
             Assert.IsTrue(status.EntriesSkipped.Count == 0);
             long origSuccess = status.FilesTransfered;
@@ -70,13 +70,13 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             localQueue.Enqueue(new DirectoryInfo(LocalPathUpload1));
             remoteQueue.Enqueue(_adlsClient.GetDirectoryEntry(RemotePathUpload1));
             Verify(localQueue, remoteQueue);
-            status = FileUploader.Upload(LocalPathUpload1, RemotePathUpload1, _adlsClient, 10, IfExists.Fail, null, false, false, false, default(CancellationToken), false, TransferChunkSize);
+            status = FileUploader.Upload(LocalPathUpload1, RemotePathUpload1, _adlsClient, 10, IfExists.Fail, null, false, false, false, false, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(origSuccess == status.EntriesSkipped.Count);
         }
         [TestMethod]
         public void TestUploadBinary()
         {
-            TransferStatus status = FileUploader.Upload(LocalPathUpload2, RemotePathUpload2, _adlsClient, 10, IfExists.Overwrite, null, false, false, true, default(CancellationToken), false, TransferChunkSize);
+            TransferStatus status = FileUploader.Upload(LocalPathUpload2, RemotePathUpload2, _adlsClient, 10, IfExists.Overwrite, null, false, true, false, true, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(status.EntriesFailed.Count == 0);
             Assert.IsTrue(status.EntriesSkipped.Count == 0);
             long origSuccess = status.FilesTransfered;
@@ -85,13 +85,25 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             localQueue.Enqueue(new DirectoryInfo(LocalPathUpload2));
             remoteQueue.Enqueue(_adlsClient.GetDirectoryEntry(RemotePathUpload2));
             Verify(localQueue, remoteQueue);
-            status = FileUploader.Upload(LocalPathUpload2, RemotePathUpload2, _adlsClient, 10, IfExists.Fail, null, false, false, true, default(CancellationToken), false, TransferChunkSize);
+            status = FileUploader.Upload(LocalPathUpload2, RemotePathUpload2, _adlsClient, 10, IfExists.Fail, null, false,false, false, true, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(origSuccess == status.EntriesSkipped.Count);
+        }
+        [TestMethod]
+        public void TestUploadResumeAndDisableTransferLogging()
+        {
+            try
+            {
+                _adlsClient.BulkUpload(LocalPathUpload2, RemotePathUpload2, 10, IfExists.Overwrite, true, null, false, true, true, default(CancellationToken));
+            }
+            catch(ArgumentException ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("resume and disablelogging both cannot be true"));
+            }
         }
         [TestMethod]
         public void TestDownload()
         {
-            TransferStatus status = FileDownloader.Download(RemotePathDownload, LocalPathDownload, _adlsClient, 25, IfExists.Overwrite, null, false, false, default(CancellationToken), false, 4194304, TransferChunkSize);//,null,IfExists.Overwrite,false,4194304,251658240L,true);
+            TransferStatus status = FileDownloader.Download(RemotePathDownload, LocalPathDownload, _adlsClient, 25, IfExists.Overwrite, null, false, false, false, default(CancellationToken), false, 4194304, TransferChunkSize);//,null,IfExists.Overwrite,false,4194304,251658240L,true);
             Assert.IsTrue(status.EntriesFailed.Count == 0);
             Assert.IsTrue(status.EntriesSkipped.Count == 0);
             long origSuccess = status.FilesTransfered;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changes to the SDK
+### Version 1.1.20
+- Fix conflict for parallel transfers for different account but same source and destination path in same host.
+- Expose the option to disable transfer logging for bulk uploads and bulk downloads.
 ### Version 1.1.19
 - Avoid throwing exception while unable to deserialize the creationtime of the trash or directory entry.
 - Expose setting per request timeout in adlsclient


### PR DESCRIPTION
Fix conflict for parallel transfers for different account but same source and destination path in same host, Expose the option to disable transfer logging for bulk uploads and bulk downloads