### PR TITLE
Add .NET Core 3.1 target

### DIFF
--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -180,6 +180,8 @@ namespace Microsoft.Azure.DataLake.Store
                          System.Runtime.InteropServices.RuntimeInformation.OSArchitecture;
 #if NETSTANDARD1_4
                 dotNetVersion = "NETSTANDARD1_4";
+#elif NETCOREAPP3_1
+                dotNetVersion="NETCOREAPP3_1";
 #else
                 dotNetVersion="NETCOREAPP1_1";
 #endif

--- a/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
+++ b/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.4;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.4;netcoreapp1.1;netcoreapp3.1</TargetFrameworks>
     <PackageId>Microsoft.Azure.DataLake.Store</PackageId>
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
-	  <Version>1.1.24</Version>
+	  <Version>1.1.25</Version>
     <FileVersion>$(Version)</FileVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Microsoft</Authors>
@@ -39,6 +39,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="NLog" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>


### PR DESCRIPTION
When trying to use the [Microsoft.Azure.DataLake.Store package](https://www.nuget.org/packages/Microsoft.Azure.DataLake.Store/) from a .NET Core 3.1+ application that specifically targets win10-x64, the package pulls in the [Microsoft.NETCore.App package](https://www.nuget.org/packages/Microsoft.NETCore.App/) dependency, which tries to use an old version of dotnet.exe and other framework assemblies.  In order to use this package from .NET Core 3.1+, we need to add some explicit things to block pulling those assemblies.  Having an explicit .NET Core 3.1 target in a new package version would help prevent this.