### PR TITLE
Fix download of large files on linux

### DIFF
--- a/AdlsDotNetSDK/FileTransfer/FileMetaData.cs
+++ b/AdlsDotNetSDK/FileTransfer/FileMetaData.cs
@@ -141,12 +141,10 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
         {
             int bytesReturned = 0;
             NativeOverlapped lpOverlapped = new NativeOverlapped();
-            bool result = DeviceIoControl(fileHandle, 590020, //FSCTL_SET_SPARSE,
+            DeviceIoControl(fileHandle, 590020, //FSCTL_SET_SPARSE,
                     IntPtr.Zero, 0, IntPtr.Zero, 0, ref bytesReturned, ref lpOverlapped);
-            if (result == false)
-            {
-                throw new Win32Exception();
-            }
+            // Lets not fail if we are not able to mark a file sparse. 
+            // This is a perf improvement. 
         }
 
         // For downloader. For chunked downloads: Creates the file if it does not exist. Else returns a write stream. This is necessary since multiple threads will write 

--- a/AdlsDotNetSDK/FileTransfer/FileMetaData.cs
+++ b/AdlsDotNetSDK/FileTransfer/FileMetaData.cs
@@ -170,7 +170,10 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
                 }
                 Utils.CreateParentDirectory(dest);
                 var fs = new FileStream(dest, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
-                MarkFileSparse(fs.SafeFileHandle);
+                if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    MarkFileSparse(fs.SafeFileHandle);
+                }
                 _downloadTempFileExists = true;
                 return fs;
             }

--- a/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
+++ b/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
@@ -3,7 +3,7 @@
 	  <TargetFrameworks>netstandard2.0;</TargetFrameworks>
 	  <PackageId>Microsoft.Azure.DataLake.Store</PackageId>
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
-	  <Version>2.0.1-alpha</Version>
+	  <Version>2.0.0-alpha.2</Version>
     <FileVersion>$(Version)</FileVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Microsoft</Authors>

--- a/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
+++ b/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
@@ -3,13 +3,13 @@
 	  <TargetFrameworks>netstandard2.0;</TargetFrameworks>
 	  <PackageId>Microsoft.Azure.DataLake.Store</PackageId>
 	  <AssemblyVersion>1.0.0</AssemblyVersion>
-	  <Version>2.0.0-alpha</Version>
+	  <Version>2.0.1-alpha</Version>
     <FileVersion>$(Version)</FileVersion>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Microsoft</Authors>
     <Description>Microsoft Azure Data Lake Store Filesystem Library for Dot Net</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Bump Netwonsoft.Json and add dot net standard 2.0 target</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix bug with bulkdownloader on non-Windows Operating Systems</PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-data-lake-store-net/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>

--- a/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
+++ b/AdlsDotNetSDK/Microsoft.Azure.DataLake.Store.csproj
@@ -9,7 +9,7 @@
     <Authors>Microsoft</Authors>
     <Description>Microsoft Azure Data Lake Store Filesystem Library for Dot Net</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Fix bug with bulkdownloader on non-Windows Operating Systems</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix bug with bulkdownloader on non-Windows Operating Systems/filesystems</PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-data-lake-store-net/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>

--- a/AdlsDotNetSDKUnitTest/CoreUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/CoreUnitTest.cs
@@ -24,6 +24,17 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         private static AdlsClient _adlsClient = SdkUnitTest.SetupSuperClient();
         private static Process _cmdProcess;
         private const int NumTests = 7;
+        private TestContext testContextInstance;
+
+        /// <summary>
+        /// Gets or sets the test context which provides
+        /// information about and functionality for the current test run.
+        /// </summary>
+        public TestContext TestContext
+        {
+            get { return testContextInstance; }
+            set { testContextInstance = value; }
+        }
         private static string TestToken = Guid.NewGuid().ToString();
         [ClassInitialize]
         public static void Setup(TestContext context)
@@ -114,7 +125,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRetry()
         {
-            int port = 8080;
+            int port = 9080;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -143,7 +154,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry1()
         {
-            int port = 8081;
+            int port = 9081;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -156,6 +167,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             Core.AppendAsync("/Test/dir", null, null, SyncFlag.DATA, 0, null, -1, 0, adlsClient, req, resp).GetAwaiter()
                 .GetResult();
             Assert.IsTrue(resp.HttpStatus == (HttpStatusCode)408);
+            TestContext.WriteLine(resp.HttpMessage);
             Assert.IsTrue(resp.HttpMessage.Equals("Request Timeout"));
             Assert.IsTrue(resp.Retries == 1);
             server.StopServer();
@@ -166,7 +178,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry2()
         {
-            int port = 8082;
+            int port = 9082;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -178,6 +190,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             Core.AppendAsync("/Test/dir", null, null, SyncFlag.DATA, 0, null, -1, 0, adlsClient, req, resp).GetAwaiter()
                 .GetResult();
             Assert.IsTrue(resp.HttpStatus == (HttpStatusCode)429);
+            TestContext.WriteLine(resp.HttpMessage);
             Assert.IsTrue(resp.HttpMessage.Equals("Too Many Requests"));
             Assert.IsTrue(resp.Retries == 1);
             server.StopServer();
@@ -188,7 +201,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry3()
         {
-            int port = 8083;
+            int port = 9083;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -235,7 +248,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestCancellation()
         {
-            int port = 8084;
+            int port = 9084;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
             server.EnqueMockResponse(new MockResponse(200, "OK"));
@@ -262,7 +275,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestTimeout()
         {
-            int port = 8085;
+            int port = 9085;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
             server.EnqueMockResponse(new MockResponse(200, "OK"));
@@ -283,6 +296,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             Assert.IsTrue(watch.ElapsedMilliseconds < 7000);
             Assert.IsNotNull(state.AdlsClient);
             Assert.IsInstanceOfType(state.Ex, typeof(Exception));
+            TestContext.WriteLine(state.Ex.Message);
             Assert.IsTrue(state.Ex.Message.Contains("Operation timed out"));
             server.StopAbruptly();
         }
@@ -290,7 +304,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConnectionBroken()
         {
-            int port = 8086;
+            int port = 9086;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
             server.EnqueMockResponse(new MockResponse(200, "OK"));
@@ -396,7 +410,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestListStatusWithArrayInResponse()
         {
-            int port = 8087;
+            int port = 9087;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -418,7 +432,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void testListStatusWithMultipleArrayInResponse()
         {
-            int port = 8088;
+            int port = 9088;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();

--- a/AdlsDotNetSDKUnitTest/CoreUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/CoreUnitTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRetry()
         {
-            int port = 9080;
+            int port = 8080;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry1()
         {
-            int port = 9081;
+            int port = 8081;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry2()
         {
-            int port = 9082;
+            int port = 8082;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestRestry3()
         {
-            int port = 9083;
+            int port = 8083;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -248,10 +248,9 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestCancellation()
         {
-            int port = 9084;
+            int port = 8084;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
-            server.EnqueMockResponse(new MockResponse(200, "OK"));
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             CancellationTokenSource source = new CancellationTokenSource();
             RequestState state = new RequestState()
@@ -261,7 +260,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             };
             Thread worker = new Thread(run);
             worker.Start(state);
-            Thread.Sleep(10000);
+            Thread.Sleep(10*1000);
             Stopwatch watch = Stopwatch.StartNew();
             source.Cancel();
             worker.Join();
@@ -275,10 +274,9 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestTimeout()
         {
-            int port = 9085;
+            int port = 8085;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
-            server.EnqueMockResponse(new MockResponse(200, "OK"));
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             CancellationTokenSource source = new CancellationTokenSource();
             RequestState state = new RequestState()
@@ -304,10 +302,9 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConnectionBroken()
         {
-            int port = 9086;
+            int port = 8086;
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
-            server.EnqueMockResponse(new MockResponse(200, "OK"));
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             CancellationTokenSource source = new CancellationTokenSource();
             RequestState state = new RequestState()
@@ -410,7 +407,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestListStatusWithArrayInResponse()
         {
-            int port = 9087;
+            int port = 8087;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();
@@ -432,7 +429,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void testListStatusWithMultipleArrayInResponse()
         {
-            int port = 9088;
+            int port = 8088;
             AdlsClient adlsClient = AdlsClient.CreateClientWithoutAccntValidation(MockWebServer.Host + ":" + port, TestToken);
             MockWebServer server = new MockWebServer(port);
             server.StartServer();

--- a/AdlsDotNetSDKUnitTest/Microsoft.Azure.DataLake.Store.UnitTest.csproj
+++ b/AdlsDotNetSDKUnitTest/Microsoft.Azure.DataLake.Store.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>    
-    <TargetFrameworks>net6.0</TargetFrameworks>    
+    <TargetFrameworks>net7.0</TargetFrameworks>    
   </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
@@ -9,7 +9,6 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>copy $(ProjectDir)NLog.config $(TargetDir)</PostBuildEvent>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\tools\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
@@ -31,6 +30,12 @@
   
   <ItemGroup>
     <None Update="template.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="NLog.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/AdlsDotNetSDKUnitTest/Microsoft.Azure.DataLake.Store.UnitTest.csproj
+++ b/AdlsDotNetSDKUnitTest/Microsoft.Azure.DataLake.Store.UnitTest.csproj
@@ -14,7 +14,7 @@
     <AssemblyOriginatorKeyFile>..\tools\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changes to the SDK
+### Version 2.0.1-alpha
+- Fix bug with bulkdownloader on non-Windows Operating Systems
+### Version 2.0.0-alpha
+- Add dot net standard 2.0 for target and upgrade newtonsoft json version in new alpha sdk version
 ### Version 1.1.24
 - Fix null character in the exception when error is recieved as chunked response
 ### Version 1.1.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes to the SDK
-### Version 2.0.1-alpha
+### Version 2.0.0-alpha.2
 - Fix bug with bulkdownloader on non-Windows Operating Systems
 ### Version 2.0.0-alpha
 - Add dot net standard 2.0 for target and upgrade newtonsoft json version in new alpha sdk version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes to the SDK
 ### Version 2.0.0-alpha.2
-- Fix bug with bulkdownloader on non-Windows Operating Systems
+- Fix bug with bulkdownloader on non-Windows Operating Systems/filesystems
 ### Version 2.0.0-alpha
 - Add dot net standard 2.0 for target and upgrade newtonsoft json version in new alpha sdk version
 ### Version 1.1.24

--- a/MockServer/MockServer.csproj
+++ b/MockServer/MockServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
@@ -12,6 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/MockServer/MockWebServer.cs
+++ b/MockServer/MockWebServer.cs
@@ -93,24 +93,35 @@ namespace MockServer
             while (true)
             {
                 MockResponse resp = GetMockResponse();
-                Console.WriteLine("Got a request. Sendiing back mock response!");
                 if (resp == null)
                 {
-                    _webListener.Close();
+                     _webListener.Close();
                     return;
                 }
+
+                try
+                { 
+                
                 var context = _webListener.GetContext();
-                context.Response.StatusCode = (int)resp.StatusCode.Value;
-                context.Response.StatusDescription = resp.StatusDescription;
+                HttpListenerRequest request = context.Request;
+                var response = context.Response;
+
+                Console.WriteLine(request.Headers.AllKeys);
+                response.StatusCode = (int)resp.StatusCode.Value;
+                response.StatusDescription = resp.StatusDescription;
                 if (resp.ResponseBody != null)
                 {
                     Wait(context.Request.InputStream);
                     var bytes = Encoding.UTF8.GetBytes(resp.ResponseBody);
-                    context.Response.ContentType = "application/json";
-                    context.Response.ContentLength64 = bytes.Length;
-                    context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length).Wait();
+                    response.ContentType = "application/json";
+                    response.ContentLength64 = bytes.Length;
+                    response.OutputStream.WriteAsync(bytes, 0, bytes.Length).Wait();
                 }
-                
+                response.Close();
+                }catch (Exception ex) {
+                    Console.WriteLine(ex);
+                    return;
+                }
             }
         }
         /// <summary>

--- a/TestDataCreator/TestDataCreator.csproj
+++ b/TestDataCreator/TestDataCreator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />


### PR DESCRIPTION
This diff adds code to skip the MarkFileSparse method on non-Windows platforms.


This seems to be a day 0 bug in the bulkdownloader code. 
MarkFileSparse method is called in the downloader when downloading a large file. This method marks the file as sparse using win32 api(https://msdn.microsoft.com/en-us/library/windows/desktop/aa364596(v=vs.85).aspx)  as a performance improvement.

 

        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364596(v=vs.85).aspx
        // Pinvoke to set the file as parse
        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
        private static extern bool DeviceIoControl(
            SafeFileHandle hDevice, int dwIoControlCode, IntPtr inBuffer, int nInBufferSize, IntPtr outBuffer, int nOutBufferSize, ref int pBytesReturned, [In] ref NativeOverlapped lpOverlapped);
        // Marks the file sparse when we create the local file during download. Otherwise if we have threads writing to the same file at different offset we have backfilling of zeros
        // meaning we are writing the file twicedue to which we get half the performance
        internal void MarkFileSparse(SafeFileHandle fileHandle)
        {
            int bytesReturned = 0;
            NativeOverlapped lpOverlapped = new NativeOverlapped();
            bool result = DeviceIoControl(fileHandle, 590020, //FSCTL_SET_SPARSE,
                    IntPtr.Zero, 0, IntPtr.Zero, 0, ref bytesReturned, ref lpOverlapped);
            if (result == false)
            {
                throw new Win32Exception();
            }
        }
 
