### PR TITLE
Add ability to pass continuation token to Get-AzDataLakeStoreDeletedItem

### DIFF
--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.DataLake.Store
                 SdkVersion = "SDKVersionUnknown";
             }
             string osInfo;
-            string dotNetVersion = "NETSTANDARD2_0-"+System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+            string dotNetVersion = "NETSTANDARD2_0-" + System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             try
             {
                 // The below calculation is wrong before net6 since Environment.ProcessorCount gives the count of logical processors not cores.
@@ -626,10 +626,10 @@ namespace Microsoft.Azure.DataLake.Store
 
             if (checkExists && entry.Type == DirectoryEntryType.DIRECTORY)
             {
-                throw new AdlsException("Cannot overwrite directory "+path);
+                throw new AdlsException("Cannot overwrite directory " + path);
             }
 
-            if(checkExists)
+            if (checkExists)
             {
 
                 resp = new OperationResponse();
@@ -667,20 +667,20 @@ namespace Microsoft.Azure.DataLake.Store
                 throw GetExceptionFromResponse(resp, $"Error in creating file {path}.");
             }
         }
-/// <summary>
-/// Synchronous API that creates a file and returns the stream to write data to that file in ADLS. The file is opened with exclusive 
-/// access - any attempt to open the same file for append will fail while this stream is open.  
-/// 
-/// Threading: The returned stream is not thread-safe.
-/// </summary>
-/// <param name="filename">File name</param>
-/// <param name="mode">Overwrites the existing file if the mode is Overwrite</param>
-/// <param name="bufferPool">Passed buffer pool</param>
-/// <param name="bufferCapacity"></param>
-/// <param name="octalPermission">Octal permission string</param>
-/// <param name="createParent">If true creates any non-existing parent directories</param>
-/// <returns>Output stream</returns>
-internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, AdlsArrayPool<byte> bufferPool, int bufferCapacity, string octalPermission = null, bool createParent = true)
+        /// <summary>
+        /// Synchronous API that creates a file and returns the stream to write data to that file in ADLS. The file is opened with exclusive 
+        /// access - any attempt to open the same file for append will fail while this stream is open.  
+        /// 
+        /// Threading: The returned stream is not thread-safe.
+        /// </summary>
+        /// <param name="filename">File name</param>
+        /// <param name="mode">Overwrites the existing file if the mode is Overwrite</param>
+        /// <param name="bufferPool">Passed buffer pool</param>
+        /// <param name="bufferCapacity"></param>
+        /// <param name="octalPermission">Octal permission string</param>
+        /// <param name="createParent">If true creates any non-existing parent directories</param>
+        /// <returns>Output stream</returns>
+        internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, AdlsArrayPool<byte> bufferPool, int bufferCapacity, string octalPermission = null, bool createParent = true)
         {
             return CreateFileAsync(filename, mode, bufferPool, bufferCapacity, octalPermission, createParent).GetAwaiter().GetResult();
         }
@@ -1395,6 +1395,16 @@ internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, Adl
             return EnumerateDeletedItemsWithTokenAsync(hint, listAfter, numResults, progressTracker, cancelToken).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Asynchronously gets the trash entries
+        /// Caution: Undeleting files is a best effort operation.  There are no guarantees that a file can be restored once it is deleted. The use of this API is enabled via whitelisting. If your ADL account is not whitelisted, then using this api will throw Not immplemented exception. For further information and assistance please contact Microsoft support.
+        /// </summary>
+        /// <param name="hint">String to match. Cannot be empty.</param>
+        /// <param name="listAfter">Token returned by system in the previous API invocation</param>
+        /// <param name="numResults">Search is executed until we find numResults or search completes. Maximum allowed value for this param is 4000. The number of returned entries could be more or less than numResults</param>
+        /// <param name="progressTracker">Object to track progress of the task. Can be null</param>
+        /// <param name="cancelToken">CancellationToken to cancel the request</param>
+        public virtual async Task<IEnumerable<TrashEntry>> EnumerateDeletedItemsAsync(string hint, string listAfter, int numResults, IProgress<EnumerateDeletedItemsProgress> progressTracker, CancellationToken cancelToken)
         {
             var result = await EnumerateDeletedItemsInternalAsync(hint, listAfter, numResults, progressTracker, cancelToken).ConfigureAwait(false);
             return result.trashEntries;

--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.DataLake.Store
                 SdkVersion = "SDKVersionUnknown";
             }
             string osInfo;
-            string dotNetVersion = "NETSTANDARD2_0-"+ System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+            string dotNetVersion = "NETSTANDARD2_0-"+System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             try
             {
                 // The below calculation is wrong before net6 since Environment.ProcessorCount gives the count of logical processors not cores.
@@ -626,7 +626,7 @@ namespace Microsoft.Azure.DataLake.Store
 
             if (checkExists && entry.Type == DirectoryEntryType.DIRECTORY)
             {
-                throw new AdlsException("Cannot overwrite directory " +path);
+                throw new AdlsException("Cannot overwrite directory "+path);
             }
 
             if(checkExists)

--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.DataLake.Store
                 SdkVersion = "SDKVersionUnknown";
             }
             string osInfo;
-            string dotNetVersion = "NETSTANDARD2_0-" + System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+            string dotNetVersion = "NETSTANDARD2_0-"+ System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             try
             {
                 // The below calculation is wrong before net6 since Environment.ProcessorCount gives the count of logical processors not cores.
@@ -626,10 +626,10 @@ namespace Microsoft.Azure.DataLake.Store
 
             if (checkExists && entry.Type == DirectoryEntryType.DIRECTORY)
             {
-                throw new AdlsException("Cannot overwrite directory " + path);
+                throw new AdlsException("Cannot overwrite directory " +path);
             }
 
-            if (checkExists)
+            if(checkExists)
             {
 
                 resp = new OperationResponse();
@@ -667,20 +667,20 @@ namespace Microsoft.Azure.DataLake.Store
                 throw GetExceptionFromResponse(resp, $"Error in creating file {path}.");
             }
         }
-        /// <summary>
-        /// Synchronous API that creates a file and returns the stream to write data to that file in ADLS. The file is opened with exclusive 
-        /// access - any attempt to open the same file for append will fail while this stream is open.  
-        /// 
-        /// Threading: The returned stream is not thread-safe.
-        /// </summary>
-        /// <param name="filename">File name</param>
-        /// <param name="mode">Overwrites the existing file if the mode is Overwrite</param>
-        /// <param name="bufferPool">Passed buffer pool</param>
-        /// <param name="bufferCapacity"></param>
-        /// <param name="octalPermission">Octal permission string</param>
-        /// <param name="createParent">If true creates any non-existing parent directories</param>
-        /// <returns>Output stream</returns>
-        internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, AdlsArrayPool<byte> bufferPool, int bufferCapacity, string octalPermission = null, bool createParent = true)
+/// <summary>
+/// Synchronous API that creates a file and returns the stream to write data to that file in ADLS. The file is opened with exclusive 
+/// access - any attempt to open the same file for append will fail while this stream is open.  
+/// 
+/// Threading: The returned stream is not thread-safe.
+/// </summary>
+/// <param name="filename">File name</param>
+/// <param name="mode">Overwrites the existing file if the mode is Overwrite</param>
+/// <param name="bufferPool">Passed buffer pool</param>
+/// <param name="bufferCapacity"></param>
+/// <param name="octalPermission">Octal permission string</param>
+/// <param name="createParent">If true creates any non-existing parent directories</param>
+/// <returns>Output stream</returns>
+internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, AdlsArrayPool<byte> bufferPool, int bufferCapacity, string octalPermission = null, bool createParent = true)
         {
             return CreateFileAsync(filename, mode, bufferPool, bufferCapacity, octalPermission, createParent).GetAwaiter().GetResult();
         }

--- a/AdlsDotNetSDK/ADLSClient.cs
+++ b/AdlsDotNetSDK/ADLSClient.cs
@@ -1390,6 +1390,7 @@ internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, Adl
         /// <param name="numResults">Search is executed until we find numResults or search completes. Maximum allowed value for this param is 4000. The number of returned entries could be more or less than numResults</param>
         /// <param name="progressTracker">Object to track progress of the task. Can be null</param>
         /// <param name="cancelToken">CancellationToken to cancel the request</param>
+        /// <returns>A tuple containing the list of trash entries and the continuation token</returns>
         public virtual (IEnumerable<TrashEntry>, string) EnumerateDeletedItemsWithToken(string hint, string listAfter, int numResults, IProgress<EnumerateDeletedItemsProgress> progressTracker, CancellationToken cancelToken = default(CancellationToken))
         {
             return EnumerateDeletedItemsWithTokenAsync(hint, listAfter, numResults, progressTracker, cancelToken).GetAwaiter().GetResult();
@@ -1419,6 +1420,7 @@ internal virtual AdlsOutputStream CreateFile(string filename, IfExists mode, Adl
         /// <param name="numResults">Search is executed until we find numResults or search completes. Maximum allowed value for this param is 4000. The number of returned entries could be more or less than numResults</param>
         /// <param name="progressTracker">Object to track progress of the task. Can be null</param>
         /// <param name="cancelToken">CancellationToken to cancel the request</param>
+        /// <returns>A tuple containing the list of trash entries and the next listAfter token</returns>
         public virtual async Task<(IEnumerable<TrashEntry>, string)> EnumerateDeletedItemsWithTokenAsync(string hint, string listAfter, int numResults, IProgress<EnumerateDeletedItemsProgress> progressTracker, CancellationToken cancelToken)
         {
             var result = await EnumerateDeletedItemsInternalAsync(hint, listAfter, numResults, progressTracker, cancelToken).ConfigureAwait(false);

--- a/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
@@ -2948,7 +2948,29 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
                 Assert.IsTrue(trashEntries.ElementAt(i).Type == TrashEntryType.DIRECTORY);
             }
         }
-        
+
+        [TestMethod]
+        public void TestTrashEnumeratePagination()
+        {
+            string prefix = GetFileOrFolderName("file");
+
+            int N = 10;
+            for (int i = 0; i < N; i++)
+            {
+                string streamName = prefix + "_" + GetFileOrFolderName("file");
+                SetupTrashFile(streamName, "file");
+            }
+
+            Thread.Sleep(3000);
+
+            // First call to get the first 50 entries
+            var (trashEntries, nextListAfter) = _adlsClient.EnumerateDeletedItemsWithToken(prefix, null, 10, null);
+
+            Assert.IsTrue(trashEntries.Count() == 10);
+            Assert.IsTrue(string.IsNullOrEmpty(nextListAfter));
+            Assert.IsTrue(trashEntries.All(entry => entry.Type == TrashEntryType.FILE));
+        }
+
         #endregion
 
         private bool VerifyGuid(string objectId)

--- a/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
@@ -2950,7 +2950,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         }
 
         [TestMethod]
-        public void TestTrashEnumeratePagination()
+        public void TestTrashEnumerateWithToken()
         {
             string prefix = GetFileOrFolderName("file");
 
@@ -2963,7 +2963,6 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
 
             Thread.Sleep(3000);
 
-            // First call to get the first 50 entries
             var (trashEntries, nextListAfter) = _adlsClient.EnumerateDeletedItemsWithToken(prefix, null, 10, null);
 
             Assert.IsTrue(trashEntries.Count() == 10);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes to the SDK
-### Version 2.0.2-alpha.1
+### Version 2.0.2
 - Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 ### Version 2.0.1
 - Version Change only to stable from alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changes to the SDK
+### Version 2.0.2-alpha.1
+- Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 ### Version 2.0.1
 - Version Change only to stable from alpha
 ### Version 2.0.1-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes to the SDK
-### Version 2.0.2-alpha
+### Version 2.0.2
 - Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 ### Version 2.0.1
 - Version Change only to stable from alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes to the SDK
-### Version 2.0.2
+### Version 2.0.2-alpha
 - Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 ### Version 2.0.1
 - Version Change only to stable from alpha


### PR DESCRIPTION
### Description:
Cosmos customers currently utilize the Azure PowerShell for restoring items. However, a limitation exists in the tool: it lacks the capability to retrieve the items by enumerating them page-wise. This change provides the capability to pass a continuation token to the Get-AzDataLakeStoreDeletedItem cmdlet so that in the next iteration, users can retrieve the next page using the continuation token. Maximum allowed value for this numResults(pagesize) is 4000. The number of returned entries could be more or less than numResults.

##### Changes Made

**Azure PowerShell** 

To enable subsequent pages to be fetched from PowerShell, 

- Define the optional parameter Continuation Token in Azure PowerShell for GetAzureRmDataLakeStoreDeletedItem command. 

- Use the continuation token to fetch subsequent pages when calling the API. 

**.NET SDK** 

Currently, the SDK returns a list of [TrashEntry](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.datalake.store.trashentry?view=azure-dotnet) which doesn’t include a continuation token. To address this, an overloaded method is introduced. 

This overloaded method will be called from Azure PowerShell.

### Testing:
![Screenshot 2025-01-22 101015](https://github.com/user-attachments/assets/259aa1b7-4c0d-4d15-8b01-fa1e62d25fcd)


![Screenshot 2025-01-22 105518](https://github.com/user-attachments/assets/4a790637-4017-419d-8ee0-e68ad244469b)

