### PR TITLE
Fix CodeQL warning for file transfer

### DIFF
--- a/AdlsDotNetSDK/FileTransfer/FileTransferCommon.cs
+++ b/AdlsDotNetSDK/FileTransfer/FileTransferCommon.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
         // Uses MD5 to hash the filename, here security is not a concern, just speed
         internal static string HashString(string fileName)
         {
-            var md5 = MD5.Create();
+            var md5 = MD5.Create(); // CodeQL [SM02196]: This is not used for cryptography, it is used for hashing filename and is not being used for any auth.
             byte[] hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(fileName));
             var sb = new StringBuilder(HashStringBuilderLength);
             foreach (byte b in hashBytes)
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
         {
             RecordedMetadata.AddRecord($"COMPLETE{TransferLog.MetaDataDelimiter}{source}", autoFlush);
         }
-        // If the transfer process is being resumed and it was successfully transfered before then we return false- meaning 
+        // If the transfer process is being resumed and it was successfully transfered before then we return false- meaning
         // it does not need to be transfered
         protected bool AddDirectoryToConsumerQueue(string dirFullName, bool isUpload)
         {
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.DataLake.Store.FileTransfer
                 }
                 else
                 {
-                    // If this file was attempted in last transfer and it is being resumed, at the enumeration time we just add the jobs for the chunks which are not 
+                    // If this file was attempted in last transfer and it is being resumed, at the enumeration time we just add the jobs for the chunks which are not
                     // reported in the log file. In reality there can be different states 1) Only those reported in resume file are done 2) More than reported are done however concat wasn't started yet
                     // 3) All chunks are actually done and concat is half done 4) All chunks are done and concat is done. The discrepancy between the resume file and actual events is because the
                     // log file is written in a separate producer-consumer queue (not serialized) for perf reasons. All these cases checked and are taken care in FileMetaData.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changes to the SDK
+### Version 2.0.3
+- Suppress CodeQL warnings for file transfer
 ### Version 2.0.2
 - Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 - Dependency updates.
@@ -50,7 +52,7 @@
 - Fix async cancellation token
 - Minor fixes: Fix MockADlsClient Create with overwrite, Fix HasAcl in copy constructor
 ### Version 1.1.13
-- Fix timeouts not getting retried 
+- Fix timeouts not getting retried
 ### Version 1.1.12
 - Increase the default thread count if physical cores is 0, Fix threadcount to be defaultthreadcount if input is 0
 - Enable getconsistent length in getfilestatus
@@ -76,7 +78,7 @@
 - Fix BulkUpload for very large files which reaches the concatenate limit
 ### Version 1.1.8
 - Fix FileTransfer upload for relative input path. Add unittest
-- Fix error message for remote exceptions which does not return json output. 
+- Fix error message for remote exceptions which does not return json output.
 - Add Authentication header length for logging and Adls exception message for 401
 - Add async api corresponding to non-async methods in mock adlsclient
 - Add cancellation token to recursive acl change and recursive DU and acl dump. Add progress tracking to recursive acl change
@@ -115,7 +117,7 @@
 - Add query parameter getConsistentLength to getfilestatus to get consistent length and pass it for open and append
 - Fix retrieving x-ms-requestid for remote exception
 - [Internal Only] In Core pass opcode as string to webtransport instead of enum
-- Fix the accessibility of Operation class 
+- Fix the accessibility of Operation class
 - For FileProperties add entry type column
 ### Version 1.0.5
 - Fix the condition for going up the tree while calculating disk usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 # Changes to the SDK
-### Version 2.0.3
-- Suppress CodeQL warnings for file transfer
 ### Version 2.0.2
 - Add ability to pass continuation token in Get-AzDataLakeStoreDeletedItem
 - Dependency updates.


### PR DESCRIPTION
This PR suppresses CodeQL warning regarding use of MD5 in FileTransfer. MD5 here is not used for any cryptographic purpose. It is used for hashing filename and is not used for any auth.

Possible solutions to fix the warning could be using SHA 256 or removing MD5 which are not necessary. Hence, the warning is being suppressed.