### PR TITLE
Skip tests which are expected to fail over symlink

### DIFF
--- a/AdlsDotNetSDKUnitTest/LongRunningUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/LongRunningUnitTest.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
 
         private static string RemotePath;
 
+        private static bool symlinkTestsDisabled = true;
         [ClassInitialize]
         public static void SetupTest(TestContext context)
         {
@@ -25,11 +26,20 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             _adlsClient.DeleteRecursive(RemotePath);
             _adlsClient.CreateDirectory(RemotePath);
             AdlsClient.ConcatenateStreamListThreshold = 10;
+            // Certain tests are expected to fail over symlink, so we skip them.
+            if (BasePath.ToLower().Contains("symlink"))
+            {
+                symlinkTestsDisabled = false;
+            }
         }
 
         [TestMethod]
         public void ParallelConcatenate()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping ParallelConcatenate because concat is not supported over symlink.");
+            }
             string path = $"{RemotePath}/A";
             string destination = $"{RemotePath}/Concatdest";
             int countFile = 400;

--- a/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/SdkUnitTest.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         private static bool _isFailureExpectedOnColon = false;
         private static string BasePath;
         private static string UnitTestDir;
+        private static bool symlinkTestsDisabled = true;
 
         public static string RandomString(int length)
         {
@@ -136,6 +137,12 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [ClassInitialize]
         public static void SetupTest(TestContext context)
         {
+            // Certain tests are expected to fail over symlink, so we skip them.
+            if (BasePath.ToLower().Contains("symlink"))
+            {
+                symlinkTestsDisabled = false;
+            }  
+
             _adlsClient = SetupSuperClient();
             
             _adlsClient.DeleteRecursive(UnitTestDir);
@@ -1082,6 +1089,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [DataRow(true)]
         public void TestRenameDirectoryDestinationExistsSubDirec(bool overwrite)
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestRenameDirectoryDestinationExistsSubDirec due to feature differences between Cosmos and Xstore.");
+            }
             string srcpath = $"{UnitTestDir}/testRenameSource1" + overwrite;
             string destPath = $"{UnitTestDir}/testRenameDestination1" + overwrite;
             string subDestpath = destPath + "/testRenameSource1" + overwrite;
@@ -1380,6 +1391,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConcatOneFile()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestConcatOneFile because concat is not supported over symlink.");
+            }
             string destPath = $"{UnitTestDir}/destPathOneFile.txt";
             string srcFile1 = $"{UnitTestDir}/Source/srcPathOneFile.txt";
             string text1 = RandomString(2 * 1024);
@@ -1473,6 +1488,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConcatTwoFile()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestConcatTwoFile because concat is not supported over symlink.");
+            }
             TestConcatTwoFile(false, UnitTestDir + "/destPath2.txt", UnitTestDir + "/Source");
             TestConcatTwoFile(true, UnitTestDir + "/destPath3.txt", UnitTestDir + "/Source1");
             TestConcatTwoFile(false, UnitTestDir + "/destPath6.txt", UnitTestDir + "/Source1", "prefix+with,signs");
@@ -1546,6 +1565,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConcatThreeFile()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestConcatThreeFile because concat is not supported over symlink.");
+            }
             TestConcatThreeFile(false, UnitTestDir + "/destPath4.txt", UnitTestDir + "/Source2");
             TestConcatThreeFile(true, UnitTestDir + "/destPath5.txt", UnitTestDir + "/Source3");
         }
@@ -1630,6 +1653,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestConcatExisting()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestConcatExisting because concat is not supported over symlink.");
+            }
             string sourcePath = UnitTestDir + "/TestConcatExisting";
             List<string> srcList = new List<string>();
             string destPath = sourcePath + "/destPath.txt";

--- a/AdlsDotNetSDKUnitTest/TransferUnitTest.cs
+++ b/AdlsDotNetSDKUnitTest/TransferUnitTest.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         private static int DataCreatorBuffSize = 2 * 1024; // At this offset there will be new lines while writing, this should be less than ADlsOutputStream.Buffercapacity.
         private static int CopyBufferSize = 4 * 1024; // Buffer size for FileCopy and ADlsOutputStream, not necessary at all just kept to catch corner cases
         private static int ReadBufferForwardSize = 8; // For nonbinary we read forward, this is the size we should read forward
+        private static bool symlinkTestsDisabled = true;
         [ClassInitialize]
         public static void SetupClassTests(TestContext context)
         {
@@ -48,10 +49,14 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
             DataCreator.CreateDirRecursiveRemote(_adlsClient, RemotePathDownload, 2, 3, 3, 4, LowFileSize, HighFileSize, true);
             DataCreator.BuffSize = DataCreatorBuffSize;
             
-
             DataCreator.CreateDirRecursiveLocal(LocalPathUpload1, 1, 3, 3, 4, LowFileSize, HighFileSize, "", true);
             DataCreator.CreateDirRecursiveLocal(LocalPathUpload2, 1, 3, 3, 4, LowFileSize, HighFileSize, "", true);
 
+            // Certain tests are expected to fail over symlink, so we skip them.
+            if (BasePath.ToLower().Contains("symlink"))
+            {
+                symlinkTestsDisabled = false;
+            } 
         }
 
         [TestInitialize]
@@ -68,6 +73,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestUploadNonBinary()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestUploadNonBinary because concat is not supported over symlink.");
+            }
             TransferStatus status = FileUploader.Upload(LocalPathUpload1, RemotePathUpload1, _adlsClient, 10, IfExists.Overwrite, null, false, false, false, false, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(status.EntriesFailed.Count == 0);
             Assert.IsTrue(status.EntriesSkipped.Count == 0);
@@ -83,6 +92,10 @@ namespace Microsoft.Azure.DataLake.Store.UnitTest
         [TestMethod]
         public void TestUploadBinary()
         {
+            if (!symlinkTestsDisabled)
+            {
+                Assert.Inconclusive("Skipping TestUploadBinary because concat is not supported over symlink.");
+            }
             TransferStatus status = FileUploader.Upload(LocalPathUpload2, RemotePathUpload2, _adlsClient, 10, IfExists.Overwrite, null, false, true, false, true, default(CancellationToken), false, TransferChunkSize);
             Assert.IsTrue(status.EntriesFailed.Count == 0);
             Assert.IsTrue(status.EntriesSkipped.Count == 0);


### PR DESCRIPTION
There are some tests which calls API which are not supported over symlink currently and are expected to fail such as concat. With this PR, we are skipping those tests, so we have cleaner test reports.